### PR TITLE
Update draft-hall-censorship-tech.md

### DIFF
--- a/draft-hall-censorship-tech.md
+++ b/draft-hall-censorship-tech.md
@@ -1256,9 +1256,16 @@ There are a variety of mechanisms that censors can use to block or
 filter access to content by altering responses from the DNS
 {{AFNIC-2013}} {{ICANN-SSAC-2012}}, including blocking the response,
 replying with an error message, or responding with an
-incorrect address (potentially to a server that can communicate to the
-end-user a reason for blocking access to that resource, for example
+incorrect address. The content at the incorrect address might
+communicate to the
+end-user a reason for blocking access to that resource.
+<!--
+, for example
 using HTTP Status Code 451 {{RFC7725}}).
+
+*** There is no indication that intrusive censoring uses 451 responses,
+and it seems unlikely that a censor would do so. ***
+-->
 
 "DNS mangling" is a network-level technique where an incorrect IP
 address is returned in response to a DNS query to a censored


### PR DESCRIPTION
Removed RFC 7725 reference because it is not used in normal censoring.